### PR TITLE
feat(admin): read-only directories for employees, facilities, and users

### DIFF
--- a/src/app/(app)/employees/[id]/page.tsx
+++ b/src/app/(app)/employees/[id]/page.tsx
@@ -1,0 +1,261 @@
+// src/app/(app)/employees/[id]/page.tsx
+// Admin view of a single employee. Shows the employee's profile, all
+// their credentials, and their shift history.
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { CredentialStatus, AssignmentStatus } from "@prisma/client";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function EmployeeDetailPage({ params }: Props) {
+  const session = await auth();
+  if (!session?.user || session.user.role !== "ADMIN") redirect("/dashboard");
+
+  const { id } = await params;
+
+  const employee = await prisma.employee.findFirst({
+    where: { id, deletedAt: null },
+    include: {
+      user: true,
+      credentials: {
+        where: { deletedAt: null },
+        orderBy: [{ type: "asc" }, { expiryDate: "desc" }],
+      },
+      assignments: {
+        include: {
+          shift: {
+            include: {
+              facility: { select: { name: true } },
+            },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+      },
+    },
+  });
+
+  if (!employee) {
+    return (
+      <div className="p-6">
+        <p className="text-sm text-slate-600">Employee not found.</p>
+        <Link
+          href="/employees"
+          className="mt-4 inline-block text-sm font-medium text-slate-700 hover:underline"
+        >
+          ← Back to employees
+        </Link>
+      </div>
+    );
+  }
+
+  const approvedCreds = employee.credentials.filter(
+    (c) => c.status === CredentialStatus.APPROVED,
+  );
+  const pendingCreds = employee.credentials.filter(
+    (c) => c.status === CredentialStatus.PENDING,
+  );
+
+  return (
+    <div className="p-6">
+      <Link
+        href="/employees"
+        className="mb-4 inline-block text-sm text-slate-600 hover:text-slate-900"
+      >
+        ← Back to employees
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-900">
+          {employee.user.firstName} {employee.user.lastName}
+        </h1>
+        <p className="mt-1 text-sm text-slate-500">
+          {employee.employeeType.replace(/_/g, " ")} · Joined{" "}
+          {employee.user.createdAt.toLocaleDateString()}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+        {/* Left column — profile */}
+        <div className="space-y-5">
+          <Card title="Profile">
+            <Row k="Email">{employee.user.email}</Row>
+            <Row k="Phone">{employee.user.phoneNumber ?? "—"}</Row>
+            <Row k="Experience">
+              {employee.yearsExperience !== null &&
+              employee.yearsExperience !== undefined
+                ? `${employee.yearsExperience} years`
+                : "—"}
+            </Row>
+            <Row k="Location">
+              {employee.city && employee.state
+                ? `${employee.city}, ${employee.state}`
+                : "—"}
+            </Row>
+          </Card>
+
+          <Card title="Summary">
+            <Row k="Approved credentials">{approvedCreds.length}</Row>
+            <Row k="Pending credentials">{pendingCreds.length}</Row>
+            <Row k="Total assignments">{employee.assignments.length}</Row>
+            <Row k="Completed shifts">
+              {
+                employee.assignments.filter(
+                  (a) => a.status === AssignmentStatus.COMPLETED,
+                ).length
+              }
+            </Row>
+          </Card>
+        </div>
+
+        {/* Right columns — credentials and shifts */}
+        <div className="lg:col-span-2 space-y-5">
+          <Card title="Credentials">
+            {employee.credentials.length === 0 ? (
+              <p className="px-4 py-3 text-sm text-slate-500">
+                No credentials on file.
+              </p>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-100 text-left text-xs uppercase tracking-wider text-slate-500">
+                    <th className="px-4 py-2 font-medium">Type</th>
+                    <th className="px-4 py-2 font-medium">Number</th>
+                    <th className="px-4 py-2 font-medium">Expires</th>
+                    <th className="px-4 py-2 font-medium">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {employee.credentials.map((c) => (
+                    <tr
+                      key={c.id}
+                      className="border-b border-slate-50 last:border-0"
+                    >
+                      <td className="px-4 py-2 text-slate-900">
+                        {c.type.replace(/_/g, " ")}
+                      </td>
+                      <td className="px-4 py-2 font-mono text-xs text-slate-600">
+                        {c.credentialNumber ?? "—"}
+                      </td>
+                      <td className="px-4 py-2 text-slate-600">
+                        {c.expiryDate.toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-2">
+                        <CredStatusBadge status={c.status} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </Card>
+
+          <Card title="Shift history">
+            {employee.assignments.length === 0 ? (
+              <p className="px-4 py-3 text-sm text-slate-500">
+                No assignments yet.
+              </p>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-100 text-left text-xs uppercase tracking-wider text-slate-500">
+                    <th className="px-4 py-2 font-medium">Shift</th>
+                    <th className="px-4 py-2 font-medium">Facility</th>
+                    <th className="px-4 py-2 font-medium">When</th>
+                    <th className="px-4 py-2 font-medium">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {employee.assignments.map((a) => (
+                    <tr
+                      key={a.id}
+                      className="border-b border-slate-50 last:border-0"
+                    >
+                      <td className="px-4 py-2 text-slate-900">
+                        {a.shift.title}
+                      </td>
+                      <td className="px-4 py-2 text-slate-600">
+                        {a.shift.facility.name}
+                      </td>
+                      <td className="px-4 py-2 text-slate-600">
+                        {a.shift.startAt.toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-2">
+                        <AssignmentStatusBadge status={a.status} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Card({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
+      <div className="border-b border-slate-100 px-4 py-2.5">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-600">
+          {title}
+        </h3>
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function Row({ k, children }: { k: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between px-4 py-2.5 border-b border-slate-50 last:border-0">
+      <dt className="text-xs text-slate-500">{k}</dt>
+      <dd className="text-sm text-slate-900 text-right">{children}</dd>
+    </div>
+  );
+}
+
+function CredStatusBadge({ status }: { status: CredentialStatus }) {
+  const map = {
+    APPROVED: "bg-emerald-50 text-emerald-700 border-emerald-200",
+    PENDING: "bg-amber-50 text-amber-700 border-amber-200",
+    REJECTED: "bg-red-50 text-red-700 border-red-200",
+    EXPIRED: "bg-slate-100 text-slate-600 border-slate-200",
+  } as const;
+  return (
+    <span
+      className={`rounded-full border px-2 py-0.5 text-xs font-medium ${map[status]}`}
+    >
+      {status.toLowerCase()}
+    </span>
+  );
+}
+
+function AssignmentStatusBadge({ status }: { status: AssignmentStatus }) {
+  const map = {
+    PROPOSED: "bg-blue-50 text-blue-700 border-blue-200",
+    CONFIRMED: "bg-emerald-50 text-emerald-700 border-emerald-200",
+    DECLINED: "bg-slate-100 text-slate-600 border-slate-200",
+    COMPLETED: "bg-slate-100 text-slate-700 border-slate-200",
+    CANCELLED: "bg-red-50 text-red-700 border-red-200",
+  } as const;
+  return (
+    <span
+      className={`rounded-full border px-2 py-0.5 text-xs font-medium ${map[status]}`}
+    >
+      {status.toLowerCase()}
+    </span>
+  );
+}

--- a/src/app/(app)/employees/page.tsx
+++ b/src/app/(app)/employees/page.tsx
@@ -1,0 +1,230 @@
+// src/app/(app)/employees/page.tsx
+// Admin directory of all employees. Read-only. Closes issue #19.
+//
+// Shows every Employee in the system with their type, contact info,
+// credential count, and shift activity. Filter by employee type.
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import {
+  EmployeeType,
+  CredentialStatus,
+  AssignmentStatus,
+} from "@prisma/client";
+
+const PAGE_SIZE = 25;
+
+const TYPE_FILTERS = [
+  { value: "ALL", label: "All types" },
+  { value: "REGISTERED_NURSE", label: "Registered Nurse" },
+  { value: "LICENSED_PRACTICAL_NURSE", label: "LPN" },
+  { value: "CERTIFIED_NURSING_ASSISTANT", label: "CNA" },
+  { value: "RESPIRATORY_THERAPIST", label: "Respiratory Therapist" },
+  { value: "MEDICAL_ASSISTANT", label: "Medical Assistant" },
+] as const;
+
+type Props = {
+  searchParams: Promise<{ type?: string; page?: string }>;
+};
+
+export default async function EmployeesPage({ searchParams }: Props) {
+  const session = await auth();
+  if (!session?.user || session.user.role !== "ADMIN") redirect("/dashboard");
+
+  const params = await searchParams;
+  const typeFilter = params.type ?? "ALL";
+  const pageNum = Math.max(1, parseInt(params.page ?? "1", 10) || 1);
+  const skip = (pageNum - 1) * PAGE_SIZE;
+
+  const whereClause = {
+    deletedAt: null,
+    ...(typeFilter !== "ALL" && {
+      employeeType: typeFilter as EmployeeType,
+    }),
+  };
+
+  const [employees, totalCount] = await Promise.all([
+    prisma.employee.findMany({
+      where: whereClause,
+      include: {
+        user: {
+          select: {
+            firstName: true,
+            lastName: true,
+            email: true,
+            createdAt: true,
+          },
+        },
+        credentials: {
+          where: {
+            deletedAt: null,
+            status: CredentialStatus.APPROVED,
+          },
+          select: { id: true },
+        },
+        assignments: {
+          where: { status: AssignmentStatus.COMPLETED },
+          select: { id: true },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      skip,
+      take: PAGE_SIZE,
+    }),
+    prisma.employee.count({ where: whereClause }),
+  ]);
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
+
+  return (
+    <div className="p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-900">
+          Employees
+        </h1>
+        <p className="mt-1 text-sm text-slate-500">
+          All credentialed healthcare workers on the platform.
+        </p>
+      </div>
+
+      {/* Filter row */}
+      <div className="mb-5 flex items-center gap-3">
+        <label className="text-xs font-medium uppercase tracking-wider text-slate-500">
+          Type:
+        </label>
+        <div className="flex flex-wrap gap-1.5">
+          {TYPE_FILTERS.map((f) => (
+            <Link
+              key={f.value}
+              href={
+                f.value === "ALL" ? "/employees" : `/employees?type=${f.value}`
+              }
+              className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+                typeFilter === f.value
+                  ? "border-slate-900 bg-slate-900 text-white"
+                  : "border-slate-200 bg-white text-slate-600 hover:border-slate-400"
+              }`}
+            >
+              {f.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-slate-200 bg-white overflow-hidden">
+        {employees.length === 0 ? (
+          <p className="px-5 py-12 text-center text-sm text-slate-500">
+            No employees match this filter.
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 text-left text-xs uppercase tracking-wider text-slate-500">
+                <th className="px-5 py-2.5 font-medium">Name</th>
+                <th className="px-5 py-2.5 font-medium">Email</th>
+                <th className="px-5 py-2.5 font-medium">Type</th>
+                <th className="px-5 py-2.5 font-medium">Experience</th>
+                <th className="px-5 py-2.5 font-medium text-center">
+                  Credentials
+                </th>
+                <th className="px-5 py-2.5 font-medium text-center">
+                  Shifts done
+                </th>
+                <th className="px-5 py-2.5 font-medium">Joined</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {employees.map((e) => (
+                <tr
+                  key={e.id}
+                  className="border-b border-slate-100 last:border-0 hover:bg-slate-50"
+                >
+                  <td className="px-5 py-3 font-medium text-slate-900">
+                    {e.user.firstName} {e.user.lastName}
+                  </td>
+                  <td className="px-5 py-3 text-slate-600">{e.user.email}</td>
+                  <td className="px-5 py-3 text-slate-700">
+                    {e.employeeType.replace(/_/g, " ")}
+                  </td>
+                  <td className="px-5 py-3 text-slate-600">
+                    {e.yearsExperience ?? "—"}{" "}
+                    {e.yearsExperience !== null &&
+                      e.yearsExperience !== undefined &&
+                      "yrs"}
+                  </td>
+                  <td className="px-5 py-3 text-center text-slate-700">
+                    {e.credentials.length}
+                  </td>
+                  <td className="px-5 py-3 text-center text-slate-700">
+                    {e.assignments.length}
+                  </td>
+                  <td className="px-5 py-3 text-slate-600">
+                    {e.user.createdAt.toLocaleDateString()}
+                  </td>
+                  <td className="px-5 py-3 text-right">
+                    <Link
+                      href={`/employees/${e.id}`}
+                      className="text-sm font-medium text-slate-700 hover:underline"
+                    >
+                      View →
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-between text-sm">
+          <p className="text-slate-500">
+            Page {pageNum} of {totalPages} · {totalCount} total
+          </p>
+          <div className="flex gap-2">
+            <PageLink
+              base={`/employees${typeFilter !== "ALL" ? `?type=${typeFilter}&` : "?"}`}
+              page={pageNum - 1}
+              disabled={pageNum <= 1}
+              label="← Prev"
+            />
+            <PageLink
+              base={`/employees${typeFilter !== "ALL" ? `?type=${typeFilter}&` : "?"}`}
+              page={pageNum + 1}
+              disabled={pageNum >= totalPages}
+              label="Next →"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PageLink({
+  base,
+  page,
+  disabled,
+  label,
+}: {
+  base: string;
+  page: number;
+  disabled: boolean;
+  label: string;
+}) {
+  const cls =
+    "rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50";
+  if (disabled) {
+    return (
+      <span className={`${cls} cursor-not-allowed opacity-40`}>{label}</span>
+    );
+  }
+  return (
+    <Link href={`${base}page=${page}`} className={cls}>
+      {label}
+    </Link>
+  );
+}

--- a/src/app/(app)/facilities/[id]/page.tsx
+++ b/src/app/(app)/facilities/[id]/page.tsx
@@ -1,0 +1,210 @@
+// src/app/(app)/facilities/[id]/page.tsx
+// Admin view of a single facility. Shows facility profile and all shifts
+// they've posted, grouped by status.
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { ShiftStatus } from "@prisma/client";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function FacilityDetailPage({ params }: Props) {
+  const session = await auth();
+  if (!session?.user || session.user.role !== "ADMIN") redirect("/dashboard");
+
+  const { id } = await params;
+
+  const facility = await prisma.facility.findFirst({
+    where: { id, deletedAt: null },
+    include: {
+      user: true,
+      shifts: {
+        include: {
+          assignments: {
+            include: {
+              employee: {
+                include: {
+                  user: { select: { firstName: true, lastName: true } },
+                },
+              },
+            },
+          },
+        },
+        orderBy: { startAt: "desc" },
+      },
+    },
+  });
+
+  if (!facility) {
+    return (
+      <div className="p-6">
+        <p className="text-sm text-slate-600">Facility not found.</p>
+        <Link
+          href="/facilities"
+          className="mt-4 inline-block text-sm font-medium text-slate-700 hover:underline"
+        >
+          ← Back to facilities
+        </Link>
+      </div>
+    );
+  }
+
+  // Group shifts by status
+  const shiftsByStatus = {
+    OPEN: facility.shifts.filter((s) => s.status === ShiftStatus.OPEN),
+    ASSIGNED: facility.shifts.filter((s) => s.status === ShiftStatus.ASSIGNED),
+    COMPLETED: facility.shifts.filter(
+      (s) => s.status === ShiftStatus.COMPLETED,
+    ),
+    CANCELLED: facility.shifts.filter(
+      (s) => s.status === ShiftStatus.CANCELLED,
+    ),
+  };
+
+  return (
+    <div className="p-6">
+      <Link
+        href="/facilities"
+        className="mb-4 inline-block text-sm text-slate-600 hover:text-slate-900"
+      >
+        ← Back to facilities
+      </Link>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-900">
+          {facility.name}
+        </h1>
+        <p className="mt-1 text-sm text-slate-500">
+          {facility.facilityType ?? "Healthcare facility"} · Joined{" "}
+          {facility.user.createdAt.toLocaleDateString()}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+        {/* Left column — profile */}
+        <div className="space-y-5">
+          <Card title="Profile">
+            <Row k="Type">{facility.facilityType ?? "—"}</Row>
+            <Row k="Contact email">{facility.user.email}</Row>
+            <Row k="Phone">{facility.user.phoneNumber ?? "—"}</Row>
+          </Card>
+
+          <Card title="Address">
+            <div className="px-4 py-3 text-sm text-slate-700 leading-relaxed">
+              {facility.addressLine1 ? (
+                <>
+                  <div>{facility.addressLine1}</div>
+                  {facility.addressLine2 && <div>{facility.addressLine2}</div>}
+                  <div>
+                    {[facility.city, facility.state, facility.zipCode]
+                      .filter(Boolean)
+                      .join(", ")}
+                  </div>
+                </>
+              ) : (
+                <span className="text-slate-500">No address on file</span>
+              )}
+            </div>
+          </Card>
+
+          <Card title="Activity">
+            <Row k="Total shifts">{facility.shifts.length}</Row>
+            <Row k="Open">{shiftsByStatus.OPEN.length}</Row>
+            <Row k="Assigned">{shiftsByStatus.ASSIGNED.length}</Row>
+            <Row k="Completed">{shiftsByStatus.COMPLETED.length}</Row>
+          </Card>
+        </div>
+
+        {/* Right columns — shifts */}
+        <div className="lg:col-span-2 space-y-5">
+          {(["OPEN", "ASSIGNED", "COMPLETED"] as const).map((status) => {
+            const shifts = shiftsByStatus[status];
+            if (shifts.length === 0) return null;
+            return (
+              <Card
+                key={status}
+                title={`${status.charAt(0)}${status.slice(1).toLowerCase()} shifts (${shifts.length})`}
+              >
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-100 text-left text-xs uppercase tracking-wider text-slate-500">
+                      <th className="px-4 py-2 font-medium">Title</th>
+                      <th className="px-4 py-2 font-medium">When</th>
+                      <th className="px-4 py-2 font-medium">Assigned to</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {shifts.map((s) => {
+                      const confirmed = s.assignments.find(
+                        (a) =>
+                          a.status === "CONFIRMED" || a.status === "COMPLETED",
+                      );
+                      return (
+                        <tr
+                          key={s.id}
+                          className="border-b border-slate-50 last:border-0"
+                        >
+                          <td className="px-4 py-2 text-slate-900">
+                            {s.title}
+                          </td>
+                          <td className="px-4 py-2 text-slate-600">
+                            {s.startAt.toLocaleDateString()}
+                          </td>
+                          <td className="px-4 py-2 text-slate-600">
+                            {confirmed
+                              ? `${confirmed.employee.user.firstName} ${confirmed.employee.user.lastName}`
+                              : "—"}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </Card>
+            );
+          })}
+
+          {facility.shifts.length === 0 && (
+            <Card title="Shifts">
+              <p className="px-4 py-3 text-sm text-slate-500">
+                This facility hasn't posted any shifts yet.
+              </p>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Card({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
+      <div className="border-b border-slate-100 px-4 py-2.5">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-600">
+          {title}
+        </h3>
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function Row({ k, children }: { k: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between px-4 py-2.5 border-b border-slate-50 last:border-0">
+      <dt className="text-xs text-slate-500">{k}</dt>
+      <dd className="text-sm text-slate-900 text-right">{children}</dd>
+    </div>
+  );
+}

--- a/src/app/(app)/facilities/page.tsx
+++ b/src/app/(app)/facilities/page.tsx
@@ -1,0 +1,157 @@
+// src/app/(app)/facilities/page.tsx
+// Admin directory of all facilities. Read-only. Closes issue #20.
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { ShiftStatus } from "@prisma/client";
+
+const PAGE_SIZE = 25;
+
+type Props = {
+  searchParams: Promise<{ page?: string }>;
+};
+
+export default async function FacilitiesPage({ searchParams }: Props) {
+  const session = await auth();
+  if (!session?.user || session.user.role !== "ADMIN") redirect("/dashboard");
+
+  const params = await searchParams;
+  const pageNum = Math.max(1, parseInt(params.page ?? "1", 10) || 1);
+  const skip = (pageNum - 1) * PAGE_SIZE;
+
+  const whereClause = { deletedAt: null };
+
+  const [facilities, totalCount] = await Promise.all([
+    prisma.facility.findMany({
+      where: whereClause,
+      include: {
+        user: {
+          select: {
+            firstName: true,
+            lastName: true,
+            email: true,
+            createdAt: true,
+          },
+        },
+        shifts: {
+          select: { id: true, status: true },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      skip,
+      take: PAGE_SIZE,
+    }),
+    prisma.facility.count({ where: whereClause }),
+  ]);
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
+
+  return (
+    <div className="p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-900">
+          Facilities
+        </h1>
+        <p className="mt-1 text-sm text-slate-500">
+          All hospitals and clinics on the platform.
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-slate-200 bg-white overflow-hidden">
+        {facilities.length === 0 ? (
+          <p className="px-5 py-12 text-center text-sm text-slate-500">
+            No facilities on the platform yet.
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 text-left text-xs uppercase tracking-wider text-slate-500">
+                <th className="px-5 py-2.5 font-medium">Name</th>
+                <th className="px-5 py-2.5 font-medium">Type</th>
+                <th className="px-5 py-2.5 font-medium">Location</th>
+                <th className="px-5 py-2.5 font-medium">Contact</th>
+                <th className="px-5 py-2.5 font-medium text-center">
+                  Open shifts
+                </th>
+                <th className="px-5 py-2.5 font-medium text-center">
+                  Total shifts
+                </th>
+                <th className="px-5 py-2.5 font-medium">Joined</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {facilities.map((f) => {
+                const openShifts = f.shifts.filter(
+                  (s) => s.status === ShiftStatus.OPEN,
+                ).length;
+                return (
+                  <tr
+                    key={f.id}
+                    className="border-b border-slate-100 last:border-0 hover:bg-slate-50"
+                  >
+                    <td className="px-5 py-3 font-medium text-slate-900">
+                      {f.name}
+                    </td>
+                    <td className="px-5 py-3 text-slate-700">
+                      {f.facilityType ?? "—"}
+                    </td>
+                    <td className="px-5 py-3 text-slate-600">
+                      {f.city && f.state ? `${f.city}, ${f.state}` : "—"}
+                    </td>
+                    <td className="px-5 py-3 text-slate-600">{f.user.email}</td>
+                    <td className="px-5 py-3 text-center text-slate-700">
+                      {openShifts}
+                    </td>
+                    <td className="px-5 py-3 text-center text-slate-700">
+                      {f.shifts.length}
+                    </td>
+                    <td className="px-5 py-3 text-slate-600">
+                      {f.user.createdAt.toLocaleDateString()}
+                    </td>
+                    <td className="px-5 py-3 text-right">
+                      <Link
+                        href={`/facilities/${f.id}`}
+                        className="text-sm font-medium text-slate-700 hover:underline"
+                      >
+                        View →
+                      </Link>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-between text-sm">
+          <p className="text-slate-500">
+            Page {pageNum} of {totalPages} · {totalCount} total
+          </p>
+          <div className="flex gap-2">
+            <Link
+              href={`/facilities?page=${pageNum - 1}`}
+              className={`rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 ${
+                pageNum <= 1 ? "pointer-events-none opacity-40" : ""
+              }`}
+            >
+              ← Prev
+            </Link>
+            <Link
+              href={`/facilities?page=${pageNum + 1}`}
+              className={`rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 ${
+                pageNum >= totalPages ? "pointer-events-none opacity-40" : ""
+              }`}
+            >
+              Next →
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/users/[id]/page.tsx
+++ b/src/app/(app)/users/[id]/page.tsx
@@ -1,0 +1,191 @@
+// src/app/(app)/users/[id]/page.tsx
+// Admin view of a single user account. Shows account metadata and links
+// to the role-specific profile (employee or facility) where applicable.
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { Role } from "@prisma/client";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function UserDetailPage({ params }: Props) {
+  const session = await auth();
+  if (!session?.user || session.user.role !== "ADMIN") redirect("/dashboard");
+
+  const { id } = await params;
+
+  const user = await prisma.user.findUnique({
+    where: { id },
+    include: {
+      employee: {
+        select: { id: true, employeeType: true },
+      },
+      facility: {
+        select: { id: true, name: true },
+      },
+    },
+  });
+
+  if (!user) {
+    return (
+      <div className="p-6">
+        <p className="text-sm text-slate-600">User not found.</p>
+        <Link
+          href="/users"
+          className="mt-4 inline-block text-sm font-medium text-slate-700 hover:underline"
+        >
+          ← Back to users
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <Link
+        href="/users"
+        className="mb-4 inline-block text-sm text-slate-600 hover:text-slate-900"
+      >
+        ← Back to users
+      </Link>
+
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">
+            {user.firstName} {user.lastName}
+          </h1>
+          <p className="mt-1 text-sm text-slate-500">
+            <RoleBadge role={user.role} /> · Created{" "}
+            {user.createdAt.toLocaleDateString()}
+          </p>
+        </div>
+        {user.deletedAt ? (
+          <span className="rounded-full border border-red-200 bg-red-50 px-3 py-1 text-xs font-medium text-red-700">
+            Inactive
+          </span>
+        ) : (
+          <span className="rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700">
+            Active
+          </span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+        <Card title="Account">
+          <Row k="Email">{user.email}</Row>
+          <Row k="Phone">{user.phoneNumber ?? "—"}</Row>
+          <Row k="Role">{user.role.toLowerCase()}</Row>
+          <Row k="Created">{user.createdAt.toLocaleDateString()}</Row>
+          {user.deletedAt && (
+            <Row k="Deactivated">{user.deletedAt.toLocaleDateString()}</Row>
+          )}
+        </Card>
+
+        <Card title="Profile">
+          {user.role === "EMPLOYEE" && user.employee && (
+            <div className="px-4 py-3 text-sm text-slate-700">
+              <p className="mb-3">
+                This account is linked to an employee profile.
+              </p>
+              <p className="mb-3 text-xs text-slate-500">
+                Type: {user.employee.employeeType.replace(/_/g, " ")}
+              </p>
+              <Link
+                href={`/employees/${user.employee.id}`}
+                className="text-sm font-medium text-slate-900 hover:underline"
+              >
+                View employee profile →
+              </Link>
+            </div>
+          )}
+
+          {user.role === "CLIENT" && user.facility && (
+            <div className="px-4 py-3 text-sm text-slate-700">
+              <p className="mb-3">This account is linked to a facility.</p>
+              <p className="mb-3 text-xs text-slate-500">
+                Facility: {user.facility.name}
+              </p>
+              <Link
+                href={`/facilities/${user.facility.id}`}
+                className="text-sm font-medium text-slate-900 hover:underline"
+              >
+                View facility profile →
+              </Link>
+            </div>
+          )}
+
+          {user.role === "ADMIN" && (
+            <div className="px-4 py-3 text-sm text-slate-700">
+              <p>This is an administrator account.</p>
+              <p className="mt-2 text-xs text-slate-500">
+                Admin accounts have full access to the platform's review and
+                management features. They are not linked to a separate profile.
+              </p>
+            </div>
+          )}
+
+          {user.role === "EMPLOYEE" && !user.employee && (
+            <div className="px-4 py-3 text-sm text-amber-700">
+              ⚠ This employee account has no profile record. This may indicate
+              an incomplete onboarding flow.
+            </div>
+          )}
+
+          {user.role === "CLIENT" && !user.facility && (
+            <div className="px-4 py-3 text-sm text-amber-700">
+              ⚠ This facility account has no facility record. This may indicate
+              an incomplete onboarding flow.
+            </div>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function Card({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
+      <div className="border-b border-slate-100 px-4 py-2.5">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-600">
+          {title}
+        </h3>
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function Row({ k, children }: { k: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between px-4 py-2.5 border-b border-slate-50 last:border-0">
+      <dt className="text-xs text-slate-500">{k}</dt>
+      <dd className="text-sm text-slate-900 text-right">{children}</dd>
+    </div>
+  );
+}
+
+function RoleBadge({ role }: { role: Role }) {
+  const map = {
+    ADMIN: "bg-violet-50 text-violet-700 border-violet-200",
+    EMPLOYEE: "bg-blue-50 text-blue-700 border-blue-200",
+    CLIENT: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  } as const;
+  return (
+    <span
+      className={`inline-block rounded-full border px-2 py-0.5 text-xs font-medium ${map[role]}`}
+    >
+      {role.toLowerCase()}
+    </span>
+  );
+}

--- a/src/app/(app)/users/page.tsx
+++ b/src/app/(app)/users/page.tsx
@@ -1,0 +1,240 @@
+// src/app/(app)/users/page.tsx
+// Admin directory of all user accounts. Read-only. Closes issue #21.
+//
+// Shows every User in the system regardless of role. Filter by role.
+// Toggle to include soft-deleted (inactive) users.
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { Role } from "@prisma/client";
+
+const PAGE_SIZE = 25;
+
+const ROLE_FILTERS = [
+  { value: "ALL", label: "All roles" },
+  { value: "ADMIN", label: "Admin" },
+  { value: "EMPLOYEE", label: "Employee" },
+  { value: "CLIENT", label: "Facility" },
+] as const;
+
+type Props = {
+  searchParams: Promise<{
+    role?: string;
+    includeInactive?: string;
+    page?: string;
+  }>;
+};
+
+export default async function UsersPage({ searchParams }: Props) {
+  const session = await auth();
+  if (!session?.user || session.user.role !== "ADMIN") redirect("/dashboard");
+
+  const params = await searchParams;
+  const roleFilter = params.role ?? "ALL";
+  const includeInactive = params.includeInactive === "true";
+  const pageNum = Math.max(1, parseInt(params.page ?? "1", 10) || 1);
+  const skip = (pageNum - 1) * PAGE_SIZE;
+
+  const whereClause = {
+    ...(!includeInactive && { deletedAt: null }),
+    ...(roleFilter !== "ALL" && {
+      role: roleFilter as Role,
+    }),
+  };
+
+  const [users, totalCount] = await Promise.all([
+    prisma.user.findMany({
+      where: whereClause,
+      orderBy: { createdAt: "desc" },
+      skip,
+      take: PAGE_SIZE,
+    }),
+    prisma.user.count({ where: whereClause }),
+  ]);
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
+
+  return (
+    <div className="p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-900">
+          Users
+        </h1>
+        <p className="mt-1 text-sm text-slate-500">
+          All accounts on the platform — admins, employees, and facility
+          clients.
+        </p>
+      </div>
+
+      {/* Filter row */}
+      <div className="mb-5 flex items-center justify-between flex-wrap gap-3">
+        <div className="flex items-center gap-3">
+          <label className="text-xs font-medium uppercase tracking-wider text-slate-500">
+            Role:
+          </label>
+          <div className="flex flex-wrap gap-1.5">
+            {ROLE_FILTERS.map((f) => (
+              <Link
+                key={f.value}
+                href={
+                  f.value === "ALL"
+                    ? buildUrl({ role: undefined, includeInactive })
+                    : buildUrl({ role: f.value, includeInactive })
+                }
+                className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+                  roleFilter === f.value
+                    ? "border-slate-900 bg-slate-900 text-white"
+                    : "border-slate-200 bg-white text-slate-600 hover:border-slate-400"
+                }`}
+              >
+                {f.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        <Link
+          href={buildUrl({
+            role: roleFilter,
+            includeInactive: !includeInactive,
+          })}
+          className={`rounded-md border px-3 py-1.5 text-xs font-medium transition ${
+            includeInactive
+              ? "border-amber-300 bg-amber-50 text-amber-800"
+              : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50"
+          }`}
+        >
+          {includeInactive ? "✓ Showing inactive" : "+ Show inactive"}
+        </Link>
+      </div>
+
+      <div className="rounded-lg border border-slate-200 bg-white overflow-hidden">
+        {users.length === 0 ? (
+          <p className="px-5 py-12 text-center text-sm text-slate-500">
+            No users match this filter.
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 text-left text-xs uppercase tracking-wider text-slate-500">
+                <th className="px-5 py-2.5 font-medium">Name</th>
+                <th className="px-5 py-2.5 font-medium">Email</th>
+                <th className="px-5 py-2.5 font-medium">Role</th>
+                <th className="px-5 py-2.5 font-medium">Status</th>
+                <th className="px-5 py-2.5 font-medium">Created</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((u) => (
+                <tr
+                  key={u.id}
+                  className="border-b border-slate-100 last:border-0 hover:bg-slate-50"
+                >
+                  <td className="px-5 py-3 font-medium text-slate-900">
+                    {u.firstName} {u.lastName}
+                  </td>
+                  <td className="px-5 py-3 text-slate-600">{u.email}</td>
+                  <td className="px-5 py-3 text-slate-700">
+                    <RoleBadge role={u.role} />
+                  </td>
+                  <td className="px-5 py-3">
+                    {u.deletedAt ? (
+                      <span className="rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700">
+                        Inactive
+                      </span>
+                    ) : (
+                      <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700">
+                        Active
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-5 py-3 text-slate-600">
+                    {u.createdAt.toLocaleDateString()}
+                  </td>
+                  <td className="px-5 py-3 text-right">
+                    <Link
+                      href={`/users/${u.id}`}
+                      className="text-sm font-medium text-slate-700 hover:underline"
+                    >
+                      View →
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-between text-sm">
+          <p className="text-slate-500">
+            Page {pageNum} of {totalPages} · {totalCount} total
+          </p>
+          <div className="flex gap-2">
+            <Link
+              href={buildUrl({
+                role: roleFilter,
+                includeInactive,
+                page: pageNum - 1,
+              })}
+              className={`rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 ${
+                pageNum <= 1 ? "pointer-events-none opacity-40" : ""
+              }`}
+            >
+              ← Prev
+            </Link>
+            <Link
+              href={buildUrl({
+                role: roleFilter,
+                includeInactive,
+                page: pageNum + 1,
+              })}
+              className={`rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 ${
+                pageNum >= totalPages ? "pointer-events-none opacity-40" : ""
+              }`}
+            >
+              Next →
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Build a query string preserving filter state across navigation
+function buildUrl({
+  role,
+  includeInactive,
+  page,
+}: {
+  role?: string;
+  includeInactive?: boolean;
+  page?: number;
+}): string {
+  const params = new URLSearchParams();
+  if (role && role !== "ALL") params.set("role", role);
+  if (includeInactive) params.set("includeInactive", "true");
+  if (page && page > 1) params.set("page", page.toString());
+  const qs = params.toString();
+  return qs ? `/users?${qs}` : "/users";
+}
+
+function RoleBadge({ role }: { role: Role }) {
+  const map = {
+    ADMIN: "bg-violet-50 text-violet-700 border-violet-200",
+    EMPLOYEE: "bg-blue-50 text-blue-700 border-blue-200",
+    CLIENT: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  } as const;
+  return (
+    <span
+      className={`inline-block rounded-full border px-2.5 py-0.5 text-xs font-medium ${map[role]}`}
+    >
+      {role.toLowerCase()}
+    </span>
+  );
+}


### PR DESCRIPTION
Closes #19, #20, #21.

Read-only admin directories for Employees, Facilities, and Users.
Each entity gets a list page with filters and pagination, plus a
detail page showing related data:
- Employees → credentials and shift history
- Facilities → posted shifts grouped by status
- Users → role-specific profile links

All routes are admin-only via session role check. No edit/delete
actions — that's deferred to future work.